### PR TITLE
FEATURE(oioswift): Add backup option to template/fileinline modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Specifically, the responsibilities of this role are to:
 | Variable   | Default | Comments (type)  |
 | :---       | :---    | :---             |
 | `openio_oioswift_app_proxy_server` | `dict` | Options of proxy-server  |
+| `openio_oioswift_backup_file_modifications` | `true` | Create a backup file including the timestamp information |
 | `openio_oioswift_bind_address` | `hostvars[inventory_hostname]['ansible_' + openio_oioswift_bind_interface]['ipv4']['address']` | IP address to use |
 | `openio_oioswift_bind_interface` | `ansible_default_ipv4.alias` | NIC name to use |
 | `openio_oioswift_bind_port` | `6007` | Port to use |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 openio_oioswift_namespace: "OPENIO"
 openio_oioswift_serviceid: "0"
 openio_oioswift_provision_only: false
+openio_oioswift_backup_file_modifications: true
 
 openio_oioswift_version: "latest"
 openio_oioswift_swift3_version: "latest"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,6 +39,7 @@
     owner: openio
     group: openio
     mode: 0644
+    backup: "{{ openio_oioswift_backup_file_modifications }}"
   with_items:
     - src: "proxy-server.conf.j2"
       dest: "{{ openio_oioswift_sysconfig_dir }}/\


### PR DESCRIPTION
 ##### SUMMARY
Configuring a default backup option to template/fileinline modules
saves modified files to allow rollbacks.
Ansible saves files using the timestamp when modified.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION