### PR TITLE
CHANGE(oioswift): Add the ability to configure OpenIO SDS proxy IP th…

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Specifically, the responsibilities of this role are to:
 | `openio_oioswift_sds_pool_connections` | `50` | Pool of connection to SDS |
 | `openio_oioswift_sds_pool_maxsize` | `50` | Maximum size of pool connection |
 | `openio_oioswift_sds_proxy_namespace` | `"openio_oioswift_namespace"` | OpenIO namespace of the oioproxy & rawx  |
-| `openio_oioswift_sds_proxy_url` | `http://{{ openio_oioswift_bind_address }}:6006` | Address of the oioproxy used |
+| `openio_oioswift_sds_proxy_interface` | `{{ openio_oioswift_bind_interface }}` | NIC name to use for OpenIO SDS proxy service |
+| `openio_oioswift_sds_proxy_url` | `http://{{ hostvars[inventory_hostname]['ansible_' + openio_oioswift_sds_proxy_interface ]['ipv4']['address'] }}:6006` | Address of the oioproxy used |
 | `openio_oioswift_sds_read_timeout` | `35` | Timeout for read operations |
 | `openio_oioswift_sds_version` | `latest` | Version of the `openio-sds-server` package  |
 | `openio_oioswift_sds_write_timeout` | `35` | Timeout for write operations |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,7 +26,9 @@ openio_oioswift_log_level: INFO
 
 # SDS
 openio_oioswift_sds_proxy_namespace: "{{ openio_oioswift_namespace }}"
-openio_oioswift_sds_proxy_url: "http://{{ openio_oioswift_proxy_bind_address }}:6006"
+openio_oioswift_sds_proxy_interface: "{{ openio_oioswift_bind_interface }}"
+openio_oioswift_sds_proxy_url:
+  "http://{{ hostvars[inventory_hostname]['ansible_' + openio_oioswift_sds_proxy_interface ]['ipv4']['address'] }}:6006"
 openio_oioswift_sds_default_account: default
 openio_oioswift_sds_connection_timeout: 5
 openio_oioswift_sds_read_timeout: 35


### PR DESCRIPTION
…rough NIC name

 ##### SUMMARY
Add the openio_oioswift_sds_proxy_interface variable to configure the OpenIO
SDS proxy using NIC name.
This change has no impact but is useful when the oioswift service and the SDS proxy
are not on the same network interface.

 ##### IMPACT
N/A