### PR TITLE
CHANGE(oioswift): Ensure service is started or restarted at the end o…

### DIFF
--- a/docker-tests/test_keystone.yml
+++ b/docker-tests/test_keystone.yml
@@ -4,14 +4,12 @@
   become: true
   vars:
     NS: TRAVIS
+    openio_bootstrap: true
   roles:
     - role: users
     - role: repository
-      openio_repository_openstack_release: 'queens'
       openio_repository_no_log: false
-      openio_repository_products:
-        sds:
-          release: "18.10"
+      openio_repository_mirror_host: mirror2.openio.io
     - role: gridinit
       openio_gridinit_namespace: "{{ NS }}"
       openio_gridinit_per_ns: true

--- a/docker-tests/test_tempauth.yml
+++ b/docker-tests/test_tempauth.yml
@@ -5,14 +5,12 @@
   become: true
   vars:
     NS: TRAVIS
+    openio_bootstrap: true
   roles:
     - role: users
     - role: repository
-      openio_repository_openstack_release: 'queens'
+      openio_repository_mirror_host: mirror2.openio.io
       openio_repository_no_log: false
-      openio_repository_products:
-        sds:
-          release: "18.10"
     - role: gridinit
       openio_gridinit_namespace: "{{ NS }}"
       openio_gridinit_per_ns: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,12 +51,38 @@
       dest: "/etc/swift/swift.conf"
   register: _oioswift_conf
 
-- name: restart oioswift
+- name: "restart oioswift to apply the new configuration"
   shell: |
     gridinit_cmd reload
     gridinit_cmd restart  {{ openio_oioswift_namespace }}-{{ openio_oioswift_servicename }}
   tags: configure
+  register: _restart_oioswift
   when:
-    - _oioswift_conf.changed
+    - _oioswift_conf is changed
     - not openio_oioswift_provision_only
+
+- block:
+    - name: "Ensure oioswift is started"
+      command: gridinit_cmd start {{ openio_oioswift_namespace }}-{{ openio_oioswift_servicename }}
+      register: _start_oioswift
+      changed_when: '"Success" in _start_oioswift.stdout'
+      when:
+        - not openio_oioswift_provision_only
+        - _restart_oioswift is skipped
+      tags: configure
+
+    - name: check oioswift
+      uri:
+        url: "http://{{ openio_oioswift_bind_address }}:{{ openio_oioswift_bind_port }}/healthcheck"
+        return_content: true
+        status_code: 200
+      register: _oioswift_check
+      retries: 3
+      delay: 5
+      until: _oioswift_check is success
+      changed_when: false
+      when:
+        - not openio_oioswift_provision_only
+  when: openio_bootstrap | d(false)
+
 ...


### PR DESCRIPTION
…f role

 ##### SUMMARY
Until 18.10, a voluntarily stopped service was not revived by a reproviosionning.

In 19.04, the `maintenance` mode becomes the default mode.

To avoid having to force (ie. deletion of conf files) the restart of a service delivered first, by error, in maintenance mode: We have to make sure that service is started and it works well at the end of the role.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION