### PR TITLE
BUGFIX/MAJOR(oioswift): Use `openio_oioswift_bind_address` to define the oioproxy address

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ Specifically, the responsibilities of this role are to:
 | `openio_oioswift_sds_pool_connections` | `500` | Pool of connection to SDS |
 | `openio_oioswift_sds_pool_maxsize` | `500` | Maximum size of pool connection |
 | `openio_oioswift_sds_proxy_namespace` | `"openio_oioswift_namespace"` | OpenIO namespace of the oioproxy & rawx  |
-| `openio_oioswift_sds_proxy_interface` | `{{ openio_oioswift_bind_interface }}` | NIC name to use for OpenIO SDS proxy service |
-| `openio_oioswift_sds_proxy_url` | `http://{{ hostvars[inventory_hostname]['ansible_' + openio_oioswift_sds_proxy_interface ]['ipv4']['address'] }}:6006` | Address of the oioproxy used |
+| `openio_oioswift_sds_proxy_url` | `http://{{ openio_oioswift_bind_address }}:6006` | Address of the oioproxy used |
 | `openio_oioswift_sds_read_timeout` | `35` | Timeout for read operations |
 | `openio_oioswift_sds_version` | `latest` | Version of the `openio-sds-server` package  |
 | `openio_oioswift_sds_write_timeout` | `35` | Timeout for write operations |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,9 +27,7 @@ openio_oioswift_log_level: INFO
 
 # SDS
 openio_oioswift_sds_proxy_namespace: "{{ openio_oioswift_namespace }}"
-openio_oioswift_sds_proxy_interface: "{{ openio_oioswift_bind_interface }}"
-openio_oioswift_sds_proxy_url:
-  "http://{{ hostvars[inventory_hostname]['ansible_' + openio_oioswift_sds_proxy_interface ]['ipv4']['address'] }}:6006"
+openio_oioswift_sds_proxy_url: "http://{{ openio_oioswift_bind_address }}:6006"
 openio_oioswift_sds_default_account: "{{ default_account | d('openio') }}"
 openio_oioswift_sds_connection_timeout: 5
 openio_oioswift_sds_read_timeout: 35


### PR DESCRIPTION

 ##### SUMMARY
On nodes with many interfaces, the `sds_proxy_url` was always set with the address on `ansible_default_ipv4.alias`

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION