### PR TITLE
CHANGE(oioswift): Disable sds_chunk_checksum_algo OS-379

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -157,7 +157,7 @@ openio_oioswift_app_proxy_server:
   allow_account_management: true
   account_autocreate: true
   log_name: "OIO,{{ openio_oioswift_namespace }},oioswift,{{ openio_oioswift_serviceid }}"
-  sds_chunk_checksum_algo: "md5"
+  sds_chunk_checksum_algo: ""
 
 openio_oioswift_filter_verb_acl:
   use: "egg:oioswift#verb_acl"


### PR DESCRIPTION
 ##### SUMMARY

We can disable internal checksum calculation to improve performance at upload

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
```shell
Cedrics-MBP-57b7:~ jack$ diff proxy_sans_modif.conf proxy_avec_modif.conf
4c4
< bind_ip = 172.17.0.11
---
> bind_ip = 172.17.0.10
47c47
< memcache_servers = 172.17.0.11:6019
---
> memcache_servers = 172.17.0.10:6019
95c95
< sds_chunk_checksum_algo = md5
---
> sds_chunk_checksum_algo =
```