### PR TITLE
CHANGE(oioswift): Set default `max_upload_part_num` to 10000

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -182,6 +182,7 @@ openio_oioswift_filter_container_hierarchy:
     else '' }}"
   sentinel_name: "{{ openio_oioswift_namespace }}-master-1"
   redis_keys_format: v2
+  max_upload_part_num: 10000
 
 openio_oioswift_filter_regexcontainer:
   use: "egg:oioswift#regexcontainer"


### PR DESCRIPTION
 ##### SUMMARY
Follow the S3 specification to upload 10000 max parts.

From openstack/swift documentation:
"Set the maximum number of parts for Upload Part operation.(default: 1000)
When setting it to be larger than the default value in order to match the
specification of S3, set to be larger max_manifest_segments for slo
middleware.(specification of S3: 10000)
max_upload_part_num = 1000
"
 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
N/A