### PR TITLE
CHANGE(oiosift): Remove `container-quotas` and `account-quotas` from CH

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -22,8 +22,6 @@ pipeline_keystone_containerhierarchy:
   - keystoneauth
   - proxy-logging
   - copy
-  - container-quotas
-  - account-quotas
   - slo
   - dlo
   - container_hierarchy


### PR DESCRIPTION
 ##### SUMMARY

Remove these middlewares improve the performance.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
If we don't set quotas (which is the case by default), they are useless.