### PR TITLE
BUGFIX/MINOR(oioswift): Fix duplicates memcached and sentinels entries

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -69,7 +69,7 @@ openio_oioswift_filter_cache:
   memcache_servers: "{{ (groups[openio_oioswift_inventory_groupname] \
     | map('extract', hostvars, ['openio_bind_address'])\
     | map('regex_replace', '$', ':6019') \
-    | join(',')) if openio_oioswift_inventory_groupname in groups \
+    | list | unique | join(',')) if openio_oioswift_inventory_groupname in groups \
     else \
     openio_oioswift_bind_address ~ ':6019' }}"
   memcache_max_connections: 500
@@ -99,7 +99,7 @@ openio_oioswift_filter_authtoken:
   memcached_servers: "{{ (groups[openio_oioswift_keystone_inventory_groupname] \
     | map('extract', hostvars, ['openio_bind_address'])\
     | map('regex_replace', '$', ':6019') \
-    | join(',')) if openio_oioswift_keystone_inventory_groupname in groups \
+    | list | unique | join(',')) if openio_oioswift_keystone_inventory_groupname in groups \
     else \
     openio_oioswift_bind_address ~ ':6019' }}"
   cache: swift.cache
@@ -180,7 +180,7 @@ openio_oioswift_filter_container_hierarchy:
   sentinel_hosts: "{{ (groups[openio_oioswift_redis_inventory_groupname] \
     | map('extract', hostvars, ['openio_bind_address'])\
     | map('regex_replace', '$', ':6012') \
-    | join(',')) if groups[openio_oioswift_redis_inventory_groupname] is defined \
+    | list | unique | join(',')) if groups[openio_oioswift_redis_inventory_groupname] is defined \
     else '' }}"
   sentinel_name: "{{ openio_oioswift_namespace }}-master-1"
   redis_keys_format: v2


### PR DESCRIPTION
 ##### SUMMARY

If same nodes are referenced many times with different names in the inventory, you have duplicates in the result list

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
Before
```
ok: [server1] =>
  msg: 10.0.2.219:6019,10.0.2.220:6019,10.0.2.217:6019,10.0.2.217:6019,10.0.2.219:6019,10.0.2.220:6019
ok: [server2] =>
  msg: 10.0.2.219:6019,10.0.2.220:6019,10.0.2.217:6019,10.0.2.217:6019,10.0.2.219:6019,10.0.2.220:6019
ok: [server3] =>
  msg: 10.0.2.219:6019,10.0.2.220:6019,10.0.2.217:6019,10.0.2.217:6019,10.0.2.219:6019,10.0.2.220:6019
ok: [server3bis] =>
  msg: 10.0.2.219:6019,10.0.2.220:6019,10.0.2.217:6019,10.0.2.217:6019,10.0.2.219:6019,10.0.2.220:6019
ok: [server1bis] =>
  msg: 10.0.2.219:6019,10.0.2.220:6019,10.0.2.217:6019,10.0.2.217:6019,10.0.2.219:6019,10.0.2.220:6019
ok: [server2bis] =>
  msg: 10.0.2.219:6019,10.0.2.220:6019,10.0.2.217:6019,10.0.2.217:6019,10.0.2.219:6019,10.0.2.220:6019
```

After:
```
ok: [server1] =>
  msg: 10.0.2.219:6019,10.0.2.220:6019,10.0.2.217:6019
ok: [server3] =>
  msg: 10.0.2.219:6019,10.0.2.220:6019,10.0.2.217:6019
ok: [server2] =>
  msg: 10.0.2.219:6019,10.0.2.220:6019,10.0.2.217:6019
ok: [server3bis] =>
  msg: 10.0.2.219:6019,10.0.2.220:6019,10.0.2.217:6019
ok: [server2bis] =>
  msg: 10.0.2.219:6019,10.0.2.220:6019,10.0.2.217:6019
ok: [server1bis] =>
  msg: 10.0.2.219:6019,10.0.2.220:6019,10.0.2.217:6019
```