### PR TITLE
CHANGE(oioswift): Add flag to force package upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Specifically, the responsibilities of this role are to:
 | `openio_oioswift_version` | `latest` | Version of the `openio-sds-swift` package |
 | `openio_oioswift_workers` | `3 ansible_processor_vcpus / 4` | Number of threads to process requests |
 | `openio_oioswift_provision_only` | `false` | Provision only without restarting services |
+| `openio_oioswift_package_upgrade` | `false` | Set the packages to the latest version (to be set in extra_vars) |
+
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 openio_oioswift_namespace: "{{ namespace | default('OPENIO') }}"
 openio_oioswift_serviceid: "{{ 0 + openio_legacy_serviceid | d(0) | int }}"
 openio_oioswift_provision_only: false
+openio_oioswift_package_upgrade: "{{ openio_package_upgrade | d(false) }}"
 openio_oioswift_backup_file_modifications: true
 
 openio_oioswift_version: "latest"

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: present
+    state: "{{ 'latest' if openio_oioswift_package_upgrade else 'present' }}"
   with_items: "{{ oioswift_packages }}"
   loop_control:
     loop_var: pkg
@@ -16,7 +16,7 @@
 - name: Install package for Erasure Code
   package:
     name: libisal2
-    state: present
+    state: "{{ 'latest' if openio_oioswift_package_upgrade else 'present' }}"
   when: openio_oioswift_sds_auto_storage_policies | map('lower') | select('match', 'ecisal') | list
   ignore_errors: "{{ ansible_check_mode }}"
   register: install_packages_isal

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: present
+    state: "{{ 'latest' if openio_oioswift_package_upgrade else 'present' }}"
   with_items: "{{ oioswift_packages }}"
   loop_control:
     loop_var: pkg
@@ -16,7 +16,7 @@
 - name: Install package for Erasure Code
   package:
     name: libisal
-    state: present
+    state: "{{ 'latest' if openio_oioswift_package_upgrade else 'present' }}"
   when: ansible_architecture == 'x86_64'
   ignore_errors: "{{ ansible_check_mode }}"
   register: install_packages_isal


### PR DESCRIPTION
 ##### SUMMARY

This is useful during upgrades, as it allows to update packages to the
latest version without requiring an external playbook/task.

To use this, simply provide the -e openio_package_upgrade=true argument

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION