### PR TITLE
CHANGE(oioswift): Split memcached group

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Specifically, the responsibilities of this role are to:
 | `openio_oioswift_gridinit_dir` | `/etc/gridinit.d/{{ openio_oioswift_namespace }}` | Path to copy the gridinit conf |
 | `openio_oioswift_gridinit_file_prefix` | `""` | Maybe set it to `{{ openio_oioswift_namespace }}-` for legacy gridinit's style |
 | `openio_oioswift_inventory_groupname` | `"oioswift"` | oioswift's groupname in your inventory |
-| `openio_oioswift_keystone_inventory_groupname` | `"keystone"` | keystone's groupname in your inventory |
+| `openio_oioswift_memcached_keystone_inventory_groupname` | `"memcached_keystone"` or `"memcached"` or `"oioswift"` | memcached groupname for keystone cache in your inventory |
+| `openio_oioswift_memcached_swift_inventory_groupname` | `"memcached_swift"` or `"memcached"` or `"oioswift"` | memcached groupname for swift cache in your inventory |
 | `openio_oioswift_log_level` | `INFO` | Log level |
 | `openio_oioswift_namespace` | `OPENIO` | OpenIO namespace for this proxy swift |
 | `openio_oioswift_pipeline` | ` pipeline_keystone` | `list` of middleware. Some preconfigured are available in `vars/main.yml` |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,8 +48,21 @@ openio_oioswift_sds_auto_storage_policies: []
 
 openio_oioswift_pipeline: "{{ pipeline_keystone_containerhierarchy }}"
 openio_oioswift_inventory_groupname: "oioswift"
-openio_oioswift_keystone_inventory_groupname: keystone
 openio_oioswift_redis_inventory_groupname: redis
+openio_oioswift_memcached_keystone_inventory_groupname: "{%- if 'memcached_keystone' in groups -%}
+  memcached_keystone
+  {%- elif 'memcached' in groups -%}
+  memcached
+  {%- else -%}
+  {{ openio_oioswift_inventory_groupname }}
+  {%- endif -%}"
+openio_oioswift_memcached_swift_inventory_groupname: "{%- if 'memcached_swift' in groups -%}
+  memcached_swift
+  {%- elif 'memcached' in groups -%}
+  memcached
+  {%- else -%}
+  {{ openio_oioswift_inventory_groupname }}
+  {%- endif -%}"
 
 openio_oioswift_filter_catch_errors:
   use: "egg:swift#catch_errors"
@@ -67,10 +80,10 @@ openio_oioswift_filter_proxy_logging:
 
 openio_oioswift_filter_cache:
   use: "egg:swift#memcache"
-  memcache_servers: "{{ (groups[openio_oioswift_inventory_groupname] \
+  memcache_servers: "{{ (groups[openio_oioswift_memcached_swift_inventory_groupname] \
     | map('extract', hostvars, ['openio_bind_address'])\
     | map('regex_replace', '$', ':6019') \
-    | list | unique | join(',')) if openio_oioswift_inventory_groupname in groups \
+    | list | unique | join(',')) if openio_oioswift_memcached_swift_inventory_groupname in groups \
     else \
     openio_oioswift_bind_address ~ ':6019' }}"
   memcache_max_connections: 500
@@ -97,10 +110,10 @@ openio_oioswift_filter_authtoken:
   password: "{{ openio_keystone_swift_password }}"
   delay_auth_decision: "True"
   include_service_catalog: "False"
-  memcached_servers: "{{ (groups[openio_oioswift_keystone_inventory_groupname] \
+  memcached_servers: "{{ (groups[openio_oioswift_memcached_keystone_inventory_groupname] \
     | map('extract', hostvars, ['openio_bind_address'])\
     | map('regex_replace', '$', ':6019') \
-    | list | unique | join(',')) if openio_oioswift_keystone_inventory_groupname in groups \
+    | list | unique | join(',')) if openio_oioswift_memcached_keystone_inventory_groupname in groups \
     else \
     openio_oioswift_bind_address ~ ':6019' }}"
   cache: swift.cache


### PR DESCRIPTION
 ##### SUMMARY

Currently, memcached is deployed on groups `oioswift` and `keystone`
without the possibility to deploy them elsewhere

Like the redis group, the memcached group can now be split into two
groups:

    memcached_keystone for keystone auth cache
    memcached_swift for swift cache

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION