### PR TITLE
CHANGE(oioswift): support the latest 1.11.0 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-[![Build Status](https://travis-ci.org/open-io/ansible-role-openio-oioswift.svg?branch=master)](https://travis-ci.org/open-io/ansible-role-openio-oioswift)
+[![Build Status](https://travis-ci.org/open-io/ansible-role-openio-oioswift.svg?branch=19.10)](https://travis-ci.org/open-io/ansible-role-openio-oioswift)
 # Ansible role `oioswift`
 
-An Ansible role for deploy an OpenIO swift gateway.
+An Ansible role for the deployment of an OpenIO swift gateway.
 Specifically, the responsibilities of this role are to:
 
 - Install package
@@ -28,6 +28,7 @@ Specifically, the responsibilities of this role are to:
 | `openio_oioswift_inventory_groupname` | `"oioswift"` | oioswift's groupname in your inventory |
 | `openio_oioswift_memcached_keystone_inventory_groupname` | `"memcached_keystone"` or `"memcached"` or `"oioswift"` | memcached groupname for keystone cache in your inventory |
 | `openio_oioswift_memcached_swift_inventory_groupname` | `"memcached_swift"` or `"memcached"` or `"oioswift"` | memcached groupname for swift cache in your inventory |
+| `openio_oioswift_location` | `"{{ openio_location_room | default ('') }}{{ openio_location_rack | default ('') }}{{ openio_location_server | default (ansible_hostname ~ '.') }}{{ openio_oioswift_serviceid }}"` | Location |
 | `openio_oioswift_log_level` | `INFO` | Log level |
 | `openio_oioswift_namespace` | `OPENIO` | OpenIO namespace for this proxy swift |
 | `openio_oioswift_pipeline` | ` pipeline_keystone` | `list` of middleware. Some preconfigured are available in `vars/main.yml` |
@@ -46,6 +47,7 @@ Specifically, the responsibilities of this role are to:
 | `openio_oioswift_sds_version` | `latest` | Version of the `openio-sds-server` package  |
 | `openio_oioswift_sds_write_timeout` | `35` | Timeout for write operations |
 | `openio_oioswift_serviceid` | `"{{ 0 + openio_legacy_serviceid | d(0) | int }}"` | Service Id in gridinit |
+| `openio_oioswift_slots` | `[oioswift]` | The service's slots in conscience |
 | `openio_oioswift_swift_constraints` | `list` | The swift-constraints section sets the basic constraints on data saved in the swift cluster |
 | `openio_oioswift_swift3_version` | `latest` | Version of the `openio-sds-swift-plugin-s3` package |
 | `openio_oioswift_version` | `latest` | Version of the `openio-sds-swift` package |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,15 @@ openio_oioswift_version: "latest"
 openio_oioswift_swift3_version: "latest"
 openio_oioswift_sds_version: "latest"
 
+openio_oioswift_location: "{{ openio_location_room | default ('') }}{{ openio_location_rack | default ('') }}\
+  {{ openio_location_server | default (ansible_hostname ~ '.') }}{{ openio_oioswift_serviceid }}"
+
+openio_oioswift_slots:
+  "{{ [ openio_oioswift_type, openio_oioswift_type ~ '-' ~ openio_oioswift_location.split('.')[:-2] \
+  | join('-') ] \
+  if openio_oioswift_location.split('.') | length > 2 \
+  else [ openio_oioswift_type ] }}"
+
 openio_oioswift_gridinit_dir: "/etc/gridinit.d/{{ openio_oioswift_namespace }}"
 openio_oioswift_gridinit_file_prefix: ""
 
@@ -71,7 +80,7 @@ openio_oioswift_filter_gatekeeper:
   use: "egg:swift#gatekeeper"
 
 openio_oioswift_filter_healthcheck:
-  use: "egg:swift#healthcheck"
+  use: "egg:oioswift#healthcheck"
 
 openio_oioswift_filter_proxy_logging:
   use: "egg:swift#proxy_logging"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,7 @@
     - path: "/etc/swift"
       owner: root
       group: root
+    - path: "{{ openio_oioswift_sysconfig_dir }}/watch"
     - path: "/var/log/oio/sds/{{ openio_oioswift_namespace }}/{{ openio_oioswift_servicename }}"
       owner: "{{ syslog_user }}"
       mode: "0750"
@@ -51,6 +52,8 @@
         {{ openio_oioswift_servicename }}.conf"
     - src: "swift.conf.j2"
       dest: "/etc/swift/swift.conf"
+    - src: "watch-oioswift.yml.j2"
+      dest: "{{ openio_oioswift_sysconfig_dir }}/watch/{{ openio_oioswift_servicename }}.yml"
   register: _oioswift_conf
   tags: configure
 

--- a/templates/gridinit_oioswift.conf.j2
+++ b/templates/gridinit_oioswift.conf.j2
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
 [Service.{{ openio_oioswift_namespace }}-{{ openio_oioswift_servicename }}]
-command=/usr/bin/swift-proxy-server  /etc/oio/sds/{{ openio_oioswift_namespace }}/{{ openio_oioswift_servicename }}/proxy-server.conf
+command=/usr/bin/oioswift-proxy-server /etc/oio/sds/{{ openio_oioswift_namespace }}/{{ openio_oioswift_servicename }}/proxy-server.conf
 enabled=true
 start_at_boot=true
 on_die=respawn

--- a/templates/watch-oioswift.yml.j2
+++ b/templates/watch-oioswift.yml.j2
@@ -1,0 +1,18 @@
+# {{ ansible_managed }}
+---
+host: {{ openio_oioswift_bind_address }}
+port: {{ openio_oioswift_bind_port }}
+type: oioswift
+{% if openio_oioswift_location | ipaddr %}
+location: {{ openio_oioswift_location | replace(".", "-") }}
+{% else %}
+location: {{ openio_oioswift_location }}
+{% endif %}
+checks:
+  - {type: http, uri: /healthcheck}
+stats:
+  - {type: system}
+  - {type: http, path: /_status, parser: json}
+slots:
+  {{ openio_oioswift_slots | to_nice_yaml | indent(2) }}
+...

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,7 @@
 ---
 openio_oioswift_sysconfig_dir: "/etc/oio/sds/{{ openio_oioswift_namespace }}"
 openio_oioswift_servicename: "oioswift-{{ openio_oioswift_serviceid }}"
+openio_oioswift_type: oioswift
 
 openio_oioswift_definition_file: >
   "{{ openio_oioswift_sysconfig_dir }}/


### PR DESCRIPTION
 ##### SUMMARY

- Start oioswift with oioswift-proxy-server script.
- Use the custom healthcheck middleware.
- Register oioswift processes in Conscience.

 ##### IMPACT
Requires oioswift>=1.11.0.

 ##### ADDITIONAL INFORMATION