### PR TITLE
CHANGE(oioswift): add max_upload_part_num on swift3 filter

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -118,6 +118,7 @@ openio_oioswift_filter_swift3:
   # always set same value
   max_bucket_listing: 1000
   max_multi_delete_objects: 1000
+  max_upload_part_num: 10000
 
 openio_oioswift_filter_tempauth:
   use: "egg:swift#tempauth"
@@ -184,8 +185,7 @@ openio_oioswift_filter_container_hierarchy:
     | list | unique | join(',')) if groups[openio_oioswift_redis_inventory_groupname] is defined \
     else '' }}"
   sentinel_name: "{{ openio_oioswift_namespace }}-master-1"
-  redis_keys_format: v2
-  max_upload_part_num: 10000
+  redis_keys_format: "{{ openio_redis_keys_format | default(default_openio_redis_keys_format) }}"
   support_listing_versioning: false
 
 openio_oioswift_filter_regexcontainer:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,6 +7,8 @@ openio_oioswift_definition_file: >
   {{ openio_oioswift_servicename }}/{{ openio_oioswift_servicename }}.conf"
 openio_oioswift_gridinit_dir: "/etc/gridinit.d/{{ openio_oioswift_namespace }}"
 
+default_openio_redis_keys_format: "v2"
+
 pipeline_keystone_containerhierarchy:
   - catch_errors
   - gatekeeper


### PR DESCRIPTION
 ##### SUMMARY

This Fix is ref on QA-17 ticket.

- max_upload_part_num` is misplaced in `container_hierarchy`, it should be in `swift3
- add default_openio_redis_keys_format.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION