### PR TITLE
BUGFIX/MINOR(oioswift): Fix missplaced `max_upload_part_num`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -144,6 +144,7 @@ openio_oioswift_filter_swift3:
   # always set same value
   max_bucket_listing: 1000
   max_multi_delete_objects: 1000
+  max_upload_part_num: 10000
 
 openio_oioswift_filter_tempauth:
   use: "egg:swift#tempauth"
@@ -211,7 +212,6 @@ openio_oioswift_filter_container_hierarchy:
     else '' }}"
   sentinel_name: "{{ openio_oioswift_namespace }}-master-1"
   redis_keys_format: v3
-  max_upload_part_num: 10000
   support_listing_versioning: false
 
 openio_oioswift_filter_regexcontainer:


### PR DESCRIPTION
 ##### SUMMARY

The option `max_upload_part_num: 10000` is missplaced.
> Set the maximum number of parts for Upload Part operation.(default: 1000)
> When setting it to be larger than the default value in order to match the
> specification of S3, set to be larger `max_manifest_segments` for slo
> middleware.(specification of S3: 10000)

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION