### PR TITLE
BUGFIX(oioswift): fix `log_name` directive misplacement since oioswift 1.11.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -164,7 +164,6 @@ openio_oioswift_app_proxy_server:
   object_post_as_copy: false
   allow_account_management: true
   account_autocreate: true
-  log_name: "OIO,{{ openio_oioswift_namespace }},oioswift,{{ openio_oioswift_serviceid }}"
   sds_chunk_checksum_algo: ""
 
 openio_oioswift_filter_verb_acl:

--- a/templates/proxy-server.conf.j2
+++ b/templates/proxy-server.conf.j2
@@ -8,6 +8,7 @@ max_clients = {{ openio_oioswift_max_clients }}
 user = openio
 log_facility = /dev/log
 log_level = {{ openio_oioswift_log_level }}
+log_name = OIO,{{ openio_oioswift_namespace }},oioswift,{{ openio_oioswift_serviceid }}
 eventlet_debug = false
 
 sds_namespace = {{ openio_oioswift_sds_proxy_namespace }}


### PR DESCRIPTION
 ##### SUMMARY
Since oioswift 1.11.0, the directive `log_name` must be in the `[DEFAULT]`
section of the configuration file `proxy-server.conf`. Before this fix, it was
in another section (`[app:proxy-server]`) and logs were not written to the
oioswift log file in `/var/log`.

As a consequence, statistics gathered from this log file
(through netdata/prometheus/grafana) were inexistant.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION