### PR TITLE
CHANGE(oioswift): Add log_s3api_command parameter to swift3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,18 @@
 # .travis.yml Execution script for role tests on Travis-CI
 ---
-dist: xenial
+dist: bionic
 sudo: required
 
 env:
   global:
-    - ANSIBLE_VERSION=2.5
+    - ANSIBLE_VERSION=2.9
   matrix:
     - DISTRIBUTION: centos
       VERSION: 7
 #    - DISTRIBUTION: centos
 #      VERSION: 8
-    - DISTRIBUTION: ubuntu
-      VERSION: 16.04
+#    - DISTRIBUTION: ubuntu
+#      VERSION: 16.04
     - DISTRIBUTION: ubuntu
       VERSION: 18.04
 #    - DISTRIBUTION: debian
@@ -20,6 +20,10 @@ env:
 
 services:
   - docker
+
+language: python
+python:
+  - "3.6"
 
 before_install:
   # Install latest Git
@@ -39,8 +43,7 @@ before_install:
   - sudo pip install --upgrade pip
   - sudo pip install ansible-lint yamllint
   # sds
-  - export IPVAGRANT=$(ip -o -4 addr list ens4 | awk '{print $4}' | cut -d/ -f1)
-  - docker run -d --net=host -e OPENIO_IPADDR=${IPVAGRANT} openio/sds
+  - docker run -d openio/sds
   - export SDS_DOCKER_ID=$(docker ps -aq)
   - while ! docker exec -ti ${SDS_DOCKER_ID}
     openio container create travis_container --oio-ns OPENIO --oio-account travis_project; do sleep 1; done
@@ -56,6 +59,6 @@ script:
 
   # Run functional tests on the container
   #- SUT_ID=$(docker ps -qa) ./docker-tests/functional-tests.sh
-  - SUT_IP=172.17.0.2 ./docker-tests/functional-tests.sh
   - SUT_IP=172.17.0.3 ./docker-tests/functional-tests.sh
+  - SUT_IP=172.17.0.4 ./docker-tests/functional-tests.sh
 ...

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -148,6 +148,7 @@ openio_oioswift_filter_swift3:
   max_bucket_listing: 1000
   max_multi_delete_objects: 1000
   max_upload_part_num: 10000
+  log_s3api_command: false
 
 openio_oioswift_filter_tempauth:
   use: "egg:swift#tempauth"

--- a/docker-tests/README.md
+++ b/docker-tests/README.md
@@ -1,20 +1,10 @@
 # Docker test environment
 
-1. Fetch the test branch: `git fetch origin docker-tests`
-2. Create a Git worktree for the test code: `git worktree add docker-tests docker-tests`. This will create a directory `docker-tests/`
-3. The script `docker-tests.sh` will create a Docker container, and apply this role from a playbook `<test.yml>`. The Docker images are configured for testing Ansible roles and are published at <https://hub.docker.com/r/cdelgehier/docker_images_ansible/>. There are images available for several distributions and versions. The distribution and version should be specified outside the script using environment variables:
+1. The script `docker-tests.sh` will create a Docker container, and apply this role from a playbook `<test.yml>`. The Docker images are configured for testing Ansible roles and are published at <https://hub.docker.com/r/bertvv/ansible-testing/>. There are images available for several distributions and versions. The distribution and version should be specified outside the script using environment variables:
 
     ```
-    DISTRIBUTION=centos VERSION=7 ANSIBLE_VERSION=2.5 ./docker-tests/docker-tests.sh
-    DISTRIBUTION=ubuntu VERSION=16.04 ANSIBLE_VERSION=2.5 ./docker-tests/docker-tests.sh
+    ANSIBLE_VERSION=2.9 DISTRIBUTION=centos VERSION=7 ./docker-tests/docker-tests.sh test_keystone
+    ANSIBLE_VERSION=2.9 DISTRIBUTION=centos VERSION=7 ./docker-tests/docker-tests.sh test_tempauth
     ```
-4. You can test another use case by adding an argument to the script. An argument `<another>` will apply a playbook `<another.yml>`
 
-5. You can run functionnal tests locally like that:
-
-    ```
-    SUT_ID=9acda29c356b ./docker-tests/functional-tests.sh
-    SUT_IP=172.17.0.2   ./docker-tests/functional-tests.sh
-    ```
-   
-The specific combinations of distributions and versions that are supported by this role are specified in `.travis.yml`.
+    The specific combinations of distributions and versions that are supported by this role are specified in `.travis.yml`.

--- a/docker-tests/checks_keystone.bats
+++ b/docker-tests/checks_keystone.bats
@@ -11,9 +11,9 @@ run_only_test() {
 }
 
 setup() {
-  run_only_test "172.17.0.2"
+  run_only_test "172.17.0.3"
   TOKEN=$(curl -i  -H "Content-Type: application/json"  -d '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"travis","domain":{"id":"default"},"password":"TRAVIS_PASS"}}},"scope":{"project":{"name":"CI","domain":{"id":"default"}}}}}' http://${SUT_IP}:5000/v3/auth/tokens | grep X-Subject-Token: | awk '{sub(/\r/, ""); print $2}')
-  STORAGE_URL=$(curl -s  -H "Content-Type: application/json"  -d '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"travis","domain":{"id":"default"},"password":"TRAVIS_PASS"}}},"scope":{"project":{"name":"CI","domain":{"id":"default"}}}}}' http://${SUT_IP}:5000/v3/auth/tokens |  python -mjson.tool | grep http://172.17.0.2:6007/v1/AUTH_ | sort -u | awk '{sub(/\r/, ""); gsub(/"/, "", $2);  print $2}')
+  STORAGE_URL=$(curl -s  -H "Content-Type: application/json"  -d '{"auth":{"identity":{"methods":["password"],"password":{"user":{"name":"travis","domain":{"id":"default"},"password":"TRAVIS_PASS"}}},"scope":{"project":{"name":"CI","domain":{"id":"default"}}}}}' http://${SUT_IP}:5000/v3/auth/tokens |  python -mjson.tool | grep http://172.17.0.3:6007/v1/AUTH_ | sort -u | awk '{sub(/\r/, ""); gsub(/"/, "", $2);  print $2}')
 }
 
 @test 'Stat account - keystoneauth' {

--- a/docker-tests/checks_tempauth.bats
+++ b/docker-tests/checks_tempauth.bats
@@ -11,7 +11,7 @@ run_only_test() {
 }
 
 setup() {
-  run_only_test "172.17.0.3"
+  run_only_test "172.17.0.4"
   TOKEN=$(curl -v -H 'X-Storage-User: travis:ci' -H 'X-Storage-Pass: TRAVIS_PASS' http://${SUT_IP}:6007/auth/v1.0  2>&1 | grep X-Auth-Token: | awk '{sub(/\r/, ""); print $3}')
   STORAGE_URL=$(curl -v -H 'X-Storage-User: travis:ci' -H 'X-Storage-Pass: TRAVIS_PASS' http://${SUT_IP}:6007/auth/v1.0  2>&1 | grep X-Storage-Url | awk '{sub(/\r/, ""); print $3}')
 }

--- a/docker-tests/test_keystone.yml
+++ b/docker-tests/test_keystone.yml
@@ -78,9 +78,9 @@
       openio_oioswift_bind_interface: "{{ ansible_default_ipv4.alias }}"
       openio_oioswift_workers: 1
       # The following namespace is not the above one "{{ NS }}", but the one from the docker image
-      openio_oioswift_sds_proxy_namespace: OPENIO
+      openio_oioswift_sds_proxy_namespace: OPENIO  # docker image
       openio_oioswift_pipeline: "{{ pipeline_keystone }}"
-      openio_oioswift_sds_proxy_url: "http://{{ lookup('env','IPVAGRANT') }}:6006"
+      openio_oioswift_sds_proxy_url: "http://172.17.0.2:6006"  # docker image
       openio_oioswift_filter_authtoken:
         paste.filter_factory: keystonemiddleware.auth_token:filter_factory
         auth_type: password

--- a/docker-tests/test_tempauth.yml
+++ b/docker-tests/test_tempauth.yml
@@ -19,10 +19,10 @@
     - role: role_under_test
       openio_oioswift_namespace: "{{ NS }}"
       openio_oioswift_bind_interface: "{{ ansible_default_ipv4.alias }}"
-      openio_oioswift_sds_proxy_url: "http://{{ lookup('env','IPVAGRANT') }}:6006"
+      openio_oioswift_sds_proxy_url: "http://172.17.0.2:6006"   # docker image
       openio_oioswift_workers: 1
       # The following namespace is not the above one "{{ NS }}", but the one from the docker image
-      openio_oioswift_sds_proxy_namespace: OPENIO
+      openio_oioswift_sds_proxy_namespace: OPENIO   # docker image
       openio_oioswift_pipeline: "{{ pipeline_tempauth }}"
       openio_oioswift_filter_tempauth:
         use: "egg:swift#tempauth"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,14 +3,14 @@ galaxy_info:
   author: Cedric DELGEHIER <cedric@openio.io>
   description: Install and configure an oioswift
   company: OpenIO
-  license: Apache
+  license: AGPLv3
 
-  min_ansible_version: 2.4
+  min_ansible_version: 2.9
 
   platforms:
     - name: Ubuntu
       versions:
-        - xenial
+        - bionic
     - name: EL
       versions:
         - 7


### PR DESCRIPTION
 ##### SUMMARY

Following 559838b089bce34899108b09c28c9d61ea7eb423 on swift3, we are able now to log s3api command.

To enable it, we have to upgrade monitoring (netdata parsing log) and enable log_s3api_command in our gateway.
By default, the value must be `false` to avoid breaking monitoring.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
R1904-47