### PR TITLE
CHANGE(oioswift): Add log_s3api_command parameter to swift3

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -123,6 +123,7 @@ openio_oioswift_filter_swift3:
   max_bucket_listing: 1000
   max_multi_delete_objects: 1000
   max_upload_part_num: 10000
+  log_s3api_command: false
 
 openio_oioswift_filter_tempauth:
   use: "egg:swift#tempauth"


### PR DESCRIPTION
 ##### SUMMARY

Following 559838b089bce34899108b09c28c9d61ea7eb423 on swift3, we are able now to log s3api command.

To enable it, we have to upgrade monitoring (netdata parsing log) and enable log_s3api_command in our gateway.
By default, the value must be `false` to avoid breaking monitoring.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
R1904-47