### PR TITLE
CHANGE(oioswift): Set redis keys to v3

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -189,7 +189,7 @@ openio_oioswift_filter_container_hierarchy:
     | list | unique | join(',')) if groups[openio_oioswift_redis_inventory_groupname] is defined \
     else '' }}"
   sentinel_name: "{{ openio_oioswift_namespace }}-master-1"
-  redis_keys_format: v2
+  redis_keys_format: v3
   support_listing_versioning: false
 
 openio_oioswift_filter_regexcontainer:


### PR DESCRIPTION
 ##### SUMMARY

Before, when setting the pipeline_containerhierarchy, it would be
deployed using the obsolete v2 redis_keys, forcing us to rewrite the
entire `openio_oioswift_filter_container_hierarchy` dict just to set
that value.

This improves on this default by setting the redis_keys_format to the
currently supported v3 version

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION