### PR TITLE
CHANGE(oioswift): Update gateway configuration to improve the check of MPUs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -173,7 +173,7 @@ openio_oioswift_filter_account_quotas:
   use: "egg:swift#account_quotas"
 
 openio_oioswift_filter_slo:
-  use: "egg:swift#slo"
+  use: "egg:oioswift#slo"
   max_manifest_segments: 10000
   concurrency: 10
 


### PR DESCRIPTION

 ##### SUMMARY

In the next version oio-swift (1.11.2), it will be possible to improve the performance of the check of MPUs (1 listing instead of several HEADs): https://github.com/open-io/oio-swift/pull/207

To benefit from this improvement, you will need to use the OpenIO version of the SLO middleware.
```ini
 # Original slo middleware
 #use = egg:swift#slo
 # OpenIO version
 use = egg:oioswift#slo
```

 ##### IMPACT
YES

 ##### ADDITIONAL INFORMATION
The Swift version of SLO middleware is still compatible with our gateway
OB-496