### PR TITLE
CHANGE(oioswift): Remove `container-quotas` and `account-quotas` from pipelines

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -67,8 +67,6 @@ pipeline_keystone:
   - keystoneauth
   - proxy-logging
   - copy
-  - container-quotas
-  - account-quotas
   - slo
   - dlo
   - versioned_writes
@@ -91,8 +89,6 @@ pipeline_keystone_iam:
   - keystoneauth
   - proxy-logging
   - copy
-  - container-quotas
-  - account-quotas
   - slo
   - dlo
   - versioned_writes
@@ -112,8 +108,6 @@ pipeline_tempauth:
   - tempauth
   - proxy-logging
   - copy
-  - container-quotas
-  - account-quotas
   - slo
   - dlo
   - versioned_writes
@@ -134,8 +128,6 @@ pipeline_tempauth_iam:
   - tempauth
   - proxy-logging
   - copy
-  - container-quotas
-  - account-quotas
   - slo
   - dlo
   - versioned_writes


### PR DESCRIPTION
 ##### SUMMARY

These two middlewares make sense only in pure swift scenarios.
S3 has no notion of quota (the more you store, the more you pay).

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION