### PR TITLE
CHANGE(oioswift): Remove `container-quotas` and `account-quotas` from pipelines

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -187,7 +187,7 @@ openio_oioswift_filter_keystoneauth:
   operator_roles: admin,swiftoperator,_member_
 
 openio_oioswift_filter_copy:
-  use: "egg:swift#copy"
+  use: "egg:oioswift#copy"
   object_post_as_copy: false
 
 openio_oioswift_filter_container_quotas:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -59,8 +59,6 @@ pipeline_keystone:
   - keystoneauth
   - proxy-logging
   - copy
-  - container-quotas
-  - account-quotas
   - slo
   - dlo
   - versioned_writes
@@ -83,8 +81,6 @@ pipeline_keystone_iam:
   - keystoneauth
   - proxy-logging
   - copy
-  - container-quotas
-  - account-quotas
   - slo
   - dlo
   - versioned_writes
@@ -126,8 +122,6 @@ pipeline_tempauth:
   - tempauth
   - proxy-logging
   - copy
-  - container-quotas
-  - account-quotas
   - slo
   - dlo
   - versioned_writes
@@ -148,8 +142,6 @@ pipeline_tempauth_iam:
   - tempauth
   - proxy-logging
   - copy
-  - container-quotas
-  - account-quotas
   - slo
   - dlo
   - versioned_writes


### PR DESCRIPTION

 ##### SUMMARY

These two middlewares make sense only in pure swift scenarios.
S3 has no notion of quota (the more you store, the more you pay).

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATIO