### PR TITLE
CHANGE(oioswift): Activate s3token secret caching

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -134,6 +134,16 @@ openio_oioswift_filter_s3token:
   use: "egg:swift3#s3token"
   delay_auth_decision: "True"
   auth_uri: "http://{{ openio_bind_virtual_address | default(openio_oioswift_bind_address) }}:35357"
+  # --- keystone token caching ---
+  auth_url: "http://{{ openio_bind_virtual_address | d(openio_oioswift_bind_address) }}:35357"
+  auth_type: password
+  password: "{{ openio_keystone_swift_password }}"
+  project_domain_id: default
+  project_name: service
+  secret_cache_duration: 60
+  user_domain_id: default
+  username: swift
+  # ---------------------------------------------------
 
 openio_oioswift_filter_keystoneauth:
   use: "egg:swift#keystoneauth"


### PR DESCRIPTION
 ##### SUMMARY

To increase performance of the s3 API retrieve and cache s3 secret
from keystone to allow for local validation.

This is a feature from swift >2.20.0 backported to swift3 1.12.20.
https://github.com/open-io/swift3/pull/75

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION

If the new configuration is applied on an old version of s3token, the
parameters will just be ignored.