### PR TITLE
CHANGE(oioswift): Use custom memcache as default with oio-swift-extended

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -71,7 +71,7 @@ openio_oioswift_filter_proxy_logging:
   access_log_headers_only: ""
 
 openio_oioswift_filter_cache:
-  use: "egg:swift#memcache"
+  use: "egg:{{ 'oioswiftext' if openio_oioswift_extended else 'swift' }}#memcache"
   memcache_servers: "{{ (groups[openio_oioswift_inventory_groupname] \
     | map('extract', hostvars, ['openio_bind_address'])\
     | map('regex_replace', '$', ':6019') \
@@ -79,6 +79,8 @@ openio_oioswift_filter_cache:
     else \
     openio_oioswift_bind_address ~ ':6019' }}"
   memcache_max_connections: 50
+  # 0 means don't expire automatically
+  oio_cache_ttl: 0
 
 openio_oioswift_filter_bulk:
   use: "egg:swift#bulk"


### PR DESCRIPTION
##### SUMMARY

When oio-swift-extended is installed, use the fork of the memcache middleware
which also caches object descriptions and container metadata.

##### IMPACT
N/A

##### ADDITIONAL INFORMATION

The default TTL is 0, which means keep entries forever (unless memory is
exhausted). Otherwise, the value is in seconds.