### PR TITLE
FEATURE(oioswift): Add parameter mpu_fallback for oio-swift-extended

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -190,6 +190,7 @@ openio_oioswift_filter_ratelimit:
 openio_oioswift_filter_hashedcontainer:
   use: "egg:oioswift#hashedcontainer"
 
+openio_oioswift_filter_container_hierarchy_mpu_fallback: false
 openio_oioswift_filter_container_hierarchy:
   use: "egg:{{ 'oioswiftext' if openio_oioswift_extended else 'oioswift' }}#container_hierarchy"
   log_level: INFO
@@ -204,6 +205,7 @@ openio_oioswift_filter_container_hierarchy:
   sentinel_name: "{{ openio_oioswift_namespace }}-master-1"
   redis_keys_format: v2
   support_listing_versioning: false
+  mpu_fallback: "{{ openio_oioswift_filter_container_hierarchy_mpu_fallback }}"
 
 openio_oioswift_filter_regexcontainer:
   use: "egg:oioswift#regexcontainer"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -203,7 +203,7 @@ openio_oioswift_filter_container_hierarchy:
     | list | unique | join(',')) if groups[openio_oioswift_redis_inventory_groupname] is defined \
     else '' }}"
   sentinel_name: "{{ openio_oioswift_namespace }}-master-1"
-  redis_keys_format: v2
+  redis_keys_format: v3
   support_listing_versioning: false
   mpu_fallback: "{{ openio_oioswift_filter_container_hierarchy_mpu_fallback }}"
 


### PR DESCRIPTION
 ##### SUMMARY

The new oio-swift-extended (requires oio-swift  1.14.1 and swift3 1.12.21-openio) allow to catch upload_id

The upload_id will now be stored in redis CH instead of meta2

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
R1904-49