### PR TITLE
FEATURE(oioswift): Add TLS support for Gateway

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,6 +31,8 @@ openio_oioswift_bind_address:
 openio_oioswift_proxy_bind_address: "{{ openio_oioswift_bind_address }}"
 openio_oioswift_bind_port: 6007
 
+openio_oioswift_sds_tls: false
+
 openio_oioswift_workers:
   "{{ ((( ansible_processor_vcpus | int ) | ternary (ansible_processor_vcpus, 1) | int ) * 3 /  4) | int }}"
 openio_oioswift_max_clients: 1024

--- a/templates/proxy-server.conf.j2
+++ b/templates/proxy-server.conf.j2
@@ -23,6 +23,8 @@ sds_pool_connections = {{ openio_oioswift_sds_pool_connections }}
 sds_pool_maxsize = {{ openio_oioswift_sds_pool_maxsize }}
 sds_max_retries = {{ openio_oioswift_sds_max_retries }}
 
+sds_tls = {{ openio_oioswift_sds_tls }}
+
 {% if openio_oioswift_sds_oio_storage_policies %}oio_storage_policies={{ openio_oioswift_sds_oio_storage_policies | join(',') }}{% endif %}
 
 {% if openio_oioswift_sds_auto_storage_policies %}auto_storage_policies={{ openio_oioswift_sds_auto_storage_policies | join(',') }}{% endif %}


### PR DESCRIPTION
 ##### SUMMARY

It will be possible to use TLS between Gateway and RAWX.

At this time, certificate have to be provided by our customer.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
https://github.com/open-io/ansible-role-openio-rawx/pull/34