### PR TITLE
CHANGE(oioswift): Replace a deprecated variable: support_listing_versioning

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -255,7 +255,7 @@ openio_oioswift_filter_container_hierarchy:
     else '' }}"
   sentinel_name: "{{ openio_oioswift_namespace }}-master-1"
   redis_keys_format: v3
-  support_listing_versioning: false
+  mask_empty_prefixes: false
   mpu_fallback: "{{ openio_oioswift_filter_container_hierarchy_mpu_fallback }}"
 
 openio_oioswift_filter_regexcontainer:


### PR DESCRIPTION
 ##### SUMMARY

Replace the deprecated "support_listing_versioning" variable by its
understandable and documented equivalent: "mask_empty_prefixes".

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
https://github.com/open-io/oio-swift/blob/1.15.0/conf/default.cfg#L246