### PR TITLE
CHANGE(oioswift): Remove `tempurl` from pipeline alias

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,7 +6,6 @@ pipeline_keystone_containerhierarchy:
   - proxy-logging
   - cache
   - bulk
-  - tempurl
   - proxy-logging
   - authtoken
   - swift3
@@ -28,7 +27,6 @@ pipeline_keystone_containerhierarchy_iam:
   - proxy-logging
   - cache
   - bulk
-  - tempurl
   - proxy-logging
   - iam
   - authtoken
@@ -51,7 +49,6 @@ pipeline_keystone:
   - proxy-logging
   - cache
   - bulk
-  - tempurl
   - proxy-logging
   - authtoken
   - swift3
@@ -72,7 +69,6 @@ pipeline_keystone_iam:
   - proxy-logging
   - cache
   - bulk
-  - tempurl
   - proxy-logging
   - iam
   - authtoken
@@ -116,7 +112,6 @@ pipeline_tempauth:
   - proxy-logging
   - cache
   - bulk
-  - tempurl
   - proxy-logging
   - swift3
   - tempauth
@@ -135,7 +130,6 @@ pipeline_tempauth_iam:
   - proxy-logging
   - cache
   - bulk
-  - tempurl
   - proxy-logging
   - iam
   - swift3


### PR DESCRIPTION
 ##### SUMMARY

`tempurl` is a swift middleware.
It's not required in our S3 context.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION