### PR TITLE
FEATURE(oioswift): activate s3_acl_openbar when iam is in the pipeline

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -172,6 +172,9 @@ openio_oioswift_filter_swift3: >-
   {%     set _ = prop.update({'bucket_db_host': hostvars[redisgrp[0]]['openio_bind_address'] ~ ':6011' }) -%}
   {%   endif -%}
   {% endif -%}
+  {% if 'iam' in openio_oioswift_pipeline -%}
+  {%   set _ = prop.update({'s3_acl_openbar': true}) -%}
+  {% endif -%}
   {{ prop }}
 
 openio_oioswift_filter_tempauth:


### PR DESCRIPTION
 ##### SUMMARY

Set `s3_acl_openbar: True` in `[filter:swift3]` when `iam` is defined in
`openio_oioswift_pipeline`

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
OS-565